### PR TITLE
Fix: Crash on Asus ROG Phone 9 when using Game Genie.

### DIFF
--- a/app/src/main/java/com/winlator/xserver/Keyboard.java
+++ b/app/src/main/java/com/winlator/xserver/Keyboard.java
@@ -101,6 +101,7 @@ public class Keyboard {
         int action = event.getAction();
         if (action == KeyEvent.ACTION_DOWN || action == KeyEvent.ACTION_UP) {
             int keyCode = event.getKeyCode();
+            if (keyCode < 0 || keyCode >= keycodeMap.length) return false; // Ignore unmapped key codes
             XKeycode xKeycode = keycodeMap[keyCode];
             if (xKeycode == null) return false;
 


### PR DESCRIPTION
Added a check to ignore unmapped key codes in onKeyEvent method to prevent crashes.

Game Genie (on Asus devices) may send invalid keycodes such as `851` or `861` during screen off/on events. This caused `Keyboard.onKeyEvent()` to index `keys[keyCode]` out of bounds (`length=159, index=851`), leading to `ArrayIndexOutOfBoundsException`.

It took me a good while, but I managed to test the fix with the current code (and my line) and it works.
If you have any questions, I will be happy to answer them.

#### Exception details
Extracted from a _logcat_ generated with `adb`:
```
FATAL EXCEPTION: main
Process: com.winlator
java.lang.ArrayIndexOutOfBoundsException: length=159 index=851
    at com.winlator.xserver.Keyboard.onKeyEvent(Keyboard.java:104)
Caused by: android.view.KeyEvent-JNI: java.lang.IllegalArgumentException: Invalid keycode 851
```
<details>
<summary>Extended logcat: (click for expand)</summary>

```
02-21 12:50:15.459  5376  5376 D GameGenieEventReceiver: onReceive: com.asus.gamecenter.game_status_changed
02-21 12:50:15.459 17038 17038 E InputEventSender: Exception dispatching finished signal for seq=12
02-21 12:50:15.459  5376  5376 D GameGenieEventReceiver: Game status: com.winlator, 11
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: Exception in MessageQueue callback: handleReceiveCallback
02-21 12:50:15.459  8843 17191 W KMViewPagerTutorial: Shouldn't do deInit()
02-21 12:50:15.459  8843 17191 I InjectServiceComm: deInit(), send DO_DESTROY message to pending task.
02-21 12:50:15.459  8843 17191 D InjectServiceComm: pushPendingTask(), item index : 17
02-21 12:50:15.459  8843 17191 D KeyMappingService: MSG_KEY_EVENT_ID, keycode = 861, action = 0
02-21 12:50:15.459  8843 17198 D InjectServiceComm: MSG_WHAT_DO_CHECK_IF_EXECUTABLE
02-21 12:50:15.459  8843 17198 D InjectServiceComm: doPendingTask(), job size = 1
02-21 12:50:15.459  8843 17198 D InjectServiceComm: parsePendingTask(), item index : 17
02-21 12:50:15.459  8843 17198 D InjectServiceComm: doPendingTask(), (after) job size = 0
02-21 12:50:15.459  8843 17198 D InjectServiceComm: MSG_WHAT_DO_DESTROY
02-21 12:50:15.459  8843 17198 I InjectServiceComm: doDestroy()
02-21 12:50:15.459  8843 17198 I InjectServiceComm: unbindPreLoaderService().
02-21 12:50:15.459  8843 17198 I GGService15: unbindPreLoaderService().
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: java.lang.ArrayIndexOutOfBoundsException: length=159; index=851
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at com.winlator.xserver.Keyboard.onKeyEvent(Keyboard.java:104)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at com.winlator.XServerDisplayActivity.dispatchKeyEvent(XServerDisplayActivity.java:816)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at androidx.appcompat.view.WindowCallbackWrapper.dispatchKeyEvent(WindowCallbackWrapper.java:59)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.dispatchKeyEvent(AppCompatDelegateImpl.java:3090)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at com.android.internal.policy.DecorView.dispatchKeyEvent(DecorView.java:392)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(ViewRootImpl.java:8409)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:8248)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:7634)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:7691)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:7657)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:7823)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:7665)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:7880)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:7638)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:7691)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:7657)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:7665)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:7638)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:7691)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:7657)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:7856)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.ViewRootImpl$ImeInputStage.onFinishedInputEvent(ViewRootImpl.java:8096)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.inputmethod.InputMethodManager$PendingEvent.run(InputMethodManager.java:5198)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.inputmethod.InputMethodManager.invokeFinishedInputEventCallback(InputMethodManager.java:4561)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.inputmethod.InputMethodManager.finishedInputEvent(InputMethodManager.java:4552)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.inputmethod.InputMethodManager.-$$Nest$mfinishedInputEvent(Unknown Source:0)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.inputmethod.InputMethodManager$ImeInputEventSender.onInputEventFinished(InputMethodManager.java:5175)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.view.InputEventSender.dispatchInputEventFinished(InputEventSender.java:181)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.os.MessageQueue.nativePollOnce(Native Method)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.os.MessageQueue.nextLegacy(MessageQueue.java:913)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.os.MessageQueue.next(MessageQueue.java:1025)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.os.Looper.loopOnce(Looper.java:220)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.os.Looper.loop(Looper.java:408)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at android.app.ActivityThread.main(ActivityThread.java:9331)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at java.lang.reflect.Method.invoke(Native Method)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
02-21 12:50:15.459 17038 17038 E MessageQueue-JNI: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:940)
02-21 12:50:15.459 17038 17038 D AndroidRuntime: Shutting down VM
02-21 12:50:15.460  8843  8843 I GameProfile: setMode(ULTRA_DURABLE >> INVALID)
02-21 12:50:15.460  4638  4654 D PwrSvrSvc: switchModeInternal reason:exit game. mIsEnterLowBat:false mPwrSvrMode:11 newMode:11
02-21 12:50:15.460  4638  4654 D PwrSvrSvc: setPowerSaverMode mPmode=11
02-21 12:50:15.460  4638  4654 D PwrSvrSvc: applySettings mode:11 reason:exit game. mIsEnterUltraModeByLowPower:false
02-21 12:50:15.460  4638  4654 W ContextImpl: Calling a method in the system process without a qualified user: android.app.ContextImpl.sendBroadcast:1269 android.content.ContextWrapper.sendBroadcast:513 com.asus.powersaver.PowerSaverService.T1:99 q.q.x2:196 q.q.onTransact:476 
02-21 12:50:15.460  8843  8843 D GameProfilePerformance: releaseCpuFocus
--------- beginning of crash
02-21 12:50:15.460 17038 17038 E AndroidRuntime: FATAL EXCEPTION: main
02-21 12:50:15.460 17038 17038 E AndroidRuntime: Process: com.winlator, PID: 17038
02-21 12:50:15.460 17038 17038 E AndroidRuntime: java.lang.ArrayIndexOutOfBoundsException: length=159; index=851
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at com.winlator.xserver.Keyboard.onKeyEvent(Keyboard.java:104)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at com.winlator.XServerDisplayActivity.dispatchKeyEvent(XServerDisplayActivity.java:816)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at androidx.appcompat.view.WindowCallbackWrapper.dispatchKeyEvent(WindowCallbackWrapper.java:59)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.dispatchKeyEvent(AppCompatDelegateImpl.java:3090)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at com.android.internal.policy.DecorView.dispatchKeyEvent(DecorView.java:392)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$ViewPostImeInputStage.processKeyEvent(ViewRootImpl.java:8409)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:8248)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:7634)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:7691)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:7657)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:7823)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:7665)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:7880)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:7638)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:7691)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:7657)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:7665)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:7638)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:7691)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:7657)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:7856)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.ViewRootImpl$ImeInputStage.onFinishedInputEvent(ViewRootImpl.java:8096)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.inputmethod.InputMethodManager$PendingEvent.run(InputMethodManager.java:5198)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.inputmethod.InputMethodManager.invokeFinishedInputEventCallback(InputMethodManager.java:4561)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.inputmethod.InputMethodManager.finishedInputEvent(InputMethodManager.java:4552)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.inputmethod.InputMethodManager.-$$Nest$mfinishedInputEvent(Unknown Source:0)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.inputmethod.InputMethodManager$ImeInputEventSender.onInputEventFinished(InputMethodManager.java:5175)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.view.InputEventSender.dispatchInputEventFinished(InputEventSender.java:181)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.os.MessageQueue.nativePollOnce(Native Method)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.os.MessageQueue.nextLegacy(MessageQueue.java:913)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.os.MessageQueue.next(MessageQueue.java:1025)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:220)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:408)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:9331)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
02-21 12:50:15.460 17038 17038 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:940)
02-21 12:50:15.460  4638  4638 D KeyMappingPlatformService: onUnbind
02-21 12:50:15.460  4638  4638 D KeyMappingPlatformService: onDestroy
```

</details>

**Update**
It seems there are more events than just turning the screen off/on that cause the crash, such as using Recent Apps with the container open. I have no idea what the hell Game Genie is trying to do spamming key codes, but now I can record the crash.

**Winlator 11 default with Game Genie active:**

https://github.com/user-attachments/assets/0cb1bf10-4a61-4a4b-a3c9-b1aa79c546b5

**With my fix applied:**

https://github.com/user-attachments/assets/0d87dcae-3b93-49f2-b71e-285638dcf09d


I don’t know how I didn’t notice this before.

------------
And, huge thanks for fixing the Toy Story 2 startup screen issue and for keeping the project going.