### PR TITLE
app: Fix virtual gamepad controls freezing on multi-touch pointer release

### DIFF
--- a/app/src/main/java/com/winlator/widget/InputControlsView.java
+++ b/app/src/main/java/com/winlator/widget/InputControlsView.java
@@ -392,10 +392,11 @@ public class InputControlsView extends View {
                     for (byte i = 0, count = (byte)event.getPointerCount(); i < count; i++) {
                         float x = event.getX(i);
                         float y = event.getY(i);
+                        int movePointerId = event.getPointerId(i);
 
                         handled = false;
                         for (ControlElement element : profile.getElements()) {
-                            if (element.handleTouchMove(i, x, y)) handled = true;
+                            if (element.handleTouchMove(movePointerId, x, y)) handled = true;
                         }
                         if (!handled) touchpadView.onTouchEvent(event);
                     }


### PR DESCRIPTION
Fixed a critical bug where virtual joystick and other touch controls would freeze when one of multiple simultaneous touch points was released.

The issue occurred because ACTION_MOVE handler was passing pointer index instead of pointer ID to ControlElement.handleTouchMove(). Pointer indices are dynamically reassigned when fingers lift, causing mismatch with the control's stored currentPointerId.

Changed to use event.getPointerId(i) to get stable pointer IDs that persist throughout the touch lifecycle, ensuring controls continue responding correctly in multi-touch scenarios.