### PR TITLE
Exclude uinput/fingerprint devices from game controller detection

### DIFF
--- a/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
+++ b/app/src/main/java/com/winlator/inputcontrols/ExternalController.java
@@ -270,6 +270,13 @@ public class ExternalController implements GamepadSlot {
 
     public static boolean isGameController(InputDevice device) {
         if (device == null) return false;
+        String name = device.getName();
+        if (name != null) {
+            String lowerName = name.toLowerCase();
+            if (lowerName.contains("uinput-fpc") || lowerName.contains("goodix_fp") || lowerName.contains("uinput-")) {
+                return false;
+            }
+        }
         int sources = device.getSources();
         return !device.isVirtual() && ((sources & InputDevice.SOURCE_GAMEPAD) == InputDevice.SOURCE_GAMEPAD ||
                (sources & InputDevice.SOURCE_JOYSTICK) == InputDevice.SOURCE_JOYSTICK);


### PR DESCRIPTION
isGameController() now returns false for input devices whose name contains uinput-, uinput-fpc, or goodix_fp, so virtual and fingerprint sensor devices are no longer mistaken for gamepads.