### PR TITLE
Add Secure Folder and secondary-profile runtime support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,10 @@
 apply plugin: 'com.android.application'
 
+import com.github.luben.zstd.ZstdInputStream
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
+
+def secureFolderJniDir = file("$buildDir/generated/secureFolderJni")
+
 android {
     compileSdk 34
 
@@ -9,6 +14,10 @@ android {
         targetSdkVersion 28
         versionCode 28
         versionName "11.1"
+
+        ndk {
+            abiFilters 'arm64-v8a'
+        }
     }
 
     buildTypes {
@@ -16,10 +25,38 @@ android {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
 
-            ndk {
-                abiFilters 'arm64-v8a'
-            }
         }
+    }
+
+    sourceSets {
+        main {
+            jniLibs.srcDir secureFolderJniDir
+        }
+    }
+
+    packagingOptions {
+        doNotStrip '**/libbox64.so'
+        doNotStrip '**/libbox64launcher.so'
+        doNotStrip '**/libglibcloader.so'
+        pickFirst '**/libc++_shared.so'
+        pickFirst '**/libFLAC.so'
+        pickFirst '**/libfluidsynth.so'
+        pickFirst '**/libfluidsynth-assetloader.so'
+        pickFirst '**/libgio-2.0.so'
+        pickFirst '**/libglib-2.0.so'
+        pickFirst '**/libgmodule-2.0.so'
+        pickFirst '**/libgobject-2.0.so'
+        pickFirst '**/libgthread-2.0.so'
+        pickFirst '**/libinstpatch-1.0.so'
+        pickFirst '**/liboboe.so'
+        pickFirst '**/libogg.so'
+        pickFirst '**/libopus.so'
+        pickFirst '**/libpcre.so'
+        pickFirst '**/libpcreposix.so'
+        pickFirst '**/libsndfile.so'
+        pickFirst '**/libvorbis.so'
+        pickFirst '**/libvorbisenc.so'
+        pickFirst '**/libvorbisfile.so'
     }
 
     lintOptions {
@@ -34,6 +71,69 @@ android {
             path 'src/main/cpp/CMakeLists.txt'
         }
     }
+}
+
+def extractTarEntry = { File archive, String entryName, File output ->
+    output.parentFile.mkdirs()
+    def found = false
+    archive.withInputStream { fileInput ->
+        new ZstdInputStream(fileInput).withCloseable { zstdInput ->
+            new TarArchiveInputStream(zstdInput).withCloseable { tarInput ->
+                def entry
+                while ((entry = tarInput.nextTarEntry) != null) {
+                    if (entry.name.replaceFirst('^\\./', '') == entryName) {
+                        output.withOutputStream { tarInput.transferTo(it) }
+                        found = true
+                        break
+                    }
+                }
+            }
+        }
+    }
+    if (!found) throw new GradleException("Missing $entryName in $archive")
+}
+
+tasks.register('generateSecureFolderRuntime') {
+    def box64Archive = file('src/main/assets/box64/box64-0.4.0.tzst')
+    def rootfsArchive = file('src/main/assets/rootfs.tzst')
+    def launcherSource = file('src/main/cpp/box64launcher/box64_launcher.c')
+    def outputDir = file("$secureFolderJniDir/arm64-v8a")
+    def box64Output = file("$outputDir/libbox64.so")
+    def loaderOutput = file("$outputDir/libglibcloader.so")
+    def launcherOutput = file("$outputDir/libbox64launcher.so")
+
+    inputs.files(box64Archive, rootfsArchive, launcherSource)
+    outputs.files(box64Output, loaderOutput, launcherOutput)
+
+    doLast {
+        delete outputDir
+        extractTarEntry(box64Archive, 'usr/local/bin/box64', box64Output)
+        extractTarEntry(rootfsArchive, 'usr/lib/ld-linux-aarch64.so.1', loaderOutput)
+
+        def hostTag
+        def osName = System.getProperty('os.name').toLowerCase(Locale.ROOT)
+        if (osName.contains('windows')) hostTag = 'windows-x86_64'
+        else if (osName.contains('mac')) hostTag = 'darwin-x86_64'
+        else hostTag = 'linux-x86_64'
+
+        def compilerName = osName.contains('windows')
+            ? 'aarch64-linux-android26-clang.cmd'
+            : 'aarch64-linux-android26-clang'
+        def compiler = new File(
+            android.ndkDirectory,
+            "toolchains/llvm/prebuilt/$hostTag/bin/$compilerName"
+        )
+        if (!compiler.isFile()) throw new GradleException("Android NDK compiler not found: $compiler")
+
+        exec {
+            commandLine compiler, '-O2', '-Wall', '-Wextra', '-Werror',
+                '-fPIE', '-pie', launcherSource, '-o', launcherOutput
+        }
+    }
+}
+
+tasks.named('preBuild').configure {
+    dependsOn tasks.named('generateSecureFolderRuntime')
 }
 
 dependencies {

--- a/app/src/main/cpp/box64launcher/box64_launcher.c
+++ b/app/src/main/cpp/box64launcher/box64_launcher.c
@@ -1,0 +1,67 @@
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+extern char** environ;
+
+static int join_path(char* output, size_t size, const char* directory, const char* name) {
+    int length = snprintf(output, size, "%s/%s", directory, name);
+    return length > 0 && (size_t)length < size;
+}
+
+int main(int argc, char** argv) {
+    const char* rootfs = getenv("WINLATOR_ROOTFS");
+    if (!rootfs || !rootfs[0]) {
+        fprintf(stderr, "box64-launcher: WINLATOR_ROOTFS is not set\n");
+        return 125;
+    }
+
+    char launcher[PATH_MAX] = {0};
+    if (!realpath(argv[0], launcher)) {
+        fprintf(stderr, "box64-launcher: realpath(%s) failed: %s\n", argv[0], strerror(errno));
+        return 125;
+    }
+
+    char native_library_dir[PATH_MAX] = {0};
+    strncpy(native_library_dir, launcher, sizeof(native_library_dir) - 1);
+    char* separator = strrchr(native_library_dir, '/');
+    if (!separator) {
+        fprintf(stderr, "box64-launcher: invalid launcher path %s\n", launcher);
+        return 125;
+    }
+    *separator = '\0';
+
+    char loader[PATH_MAX] = {0};
+    char box64[PATH_MAX] = {0};
+    char rootfs_lib[PATH_MAX] = {0};
+    if (!join_path(loader, sizeof(loader), native_library_dir, "libglibcloader.so")
+        || !join_path(box64, sizeof(box64), native_library_dir, "libbox64.so")
+        || !join_path(rootfs_lib, sizeof(rootfs_lib), rootfs, "lib")) {
+        fprintf(stderr, "box64-launcher: runtime path is too long\n");
+        return 125;
+    }
+
+    char** child_argv = calloc((size_t)argc + 7, sizeof(char*));
+    if (!child_argv) {
+        fprintf(stderr, "box64-launcher: unable to allocate arguments\n");
+        return 125;
+    }
+
+    int index = 0;
+    child_argv[index++] = loader;
+    child_argv[index++] = "--library-path";
+    child_argv[index++] = rootfs_lib;
+    child_argv[index++] = "--argv0";
+    child_argv[index++] = launcher;
+    child_argv[index++] = box64;
+    for (int i = 1; i < argc; i++) child_argv[index++] = argv[i];
+    child_argv[index] = NULL;
+
+    execve(loader, child_argv, environ);
+    fprintf(stderr, "box64-launcher: execve(%s) failed: %s\n", loader, strerror(errno));
+    free(child_argv);
+    return 126;
+}

--- a/app/src/main/cpp/gladiorenderer/include/gladio.h
+++ b/app/src/main/cpp/gladiorenderer/include/gladio.h
@@ -12,6 +12,8 @@
 #define CLIENT_RING_BUFFER_SIZE 33554432
 #define THREAD_POOL_NUM_THREADS 4
 #define PIXEL_READ_CACHE_SKIP_FRAMES 3
+// Compiled into the rootfs-side libGL; ProfilePathRelocator rewrites this fixed path per profile.
+#define X11_SERVER_PATH "/data/data/com.winlator/files/rootfs/tmp/.X11-unix/X0"
 #define GL_STRING_VERSION "3.3"
 #define GL_STRING_RENDERER "Gladio"
 #define GL_STRING_SHADING_LANGUAGE_VERSION "3.30"

--- a/app/src/main/cpp/gladiorenderer/include/gladio.h
+++ b/app/src/main/cpp/gladiorenderer/include/gladio.h
@@ -12,8 +12,6 @@
 #define CLIENT_RING_BUFFER_SIZE 33554432
 #define THREAD_POOL_NUM_THREADS 4
 #define PIXEL_READ_CACHE_SKIP_FRAMES 3
-#define X11_SERVER_PATH "/data/data/com.winlator/files/rootfs/tmp/.X11-unix/X0"
-
 #define GL_STRING_VERSION "3.3"
 #define GL_STRING_RENDERER "Gladio"
 #define GL_STRING_SHADING_LANGUAGE_VERSION "3.30"

--- a/app/src/main/cpp/vortekrenderer/include/vortek.h
+++ b/app/src/main/cpp/vortekrenderer/include/vortek.h
@@ -5,6 +5,8 @@
 #define MEMORY_POOL_MAX_SIZE 65536
 #define SERVER_RING_BUFFER_SIZE 4194304
 #define CLIENT_RING_BUFFER_SIZE 262144
+// Compiled into the rootfs-side libvulkan_vortek; ProfilePathRelocator rewrites this fixed path per profile.
+#define VORTEK_SERVER_PATH "/data/data/com.winlator/files/rootfs/tmp/.vortek/V0"
 #define VK_HANDLE_BYTE_COUNT 8
 #define THREAD_POOL_NUM_THREADS 8
 

--- a/app/src/main/cpp/vortekrenderer/include/vortek.h
+++ b/app/src/main/cpp/vortekrenderer/include/vortek.h
@@ -5,7 +5,6 @@
 #define MEMORY_POOL_MAX_SIZE 65536
 #define SERVER_RING_BUFFER_SIZE 4194304
 #define CLIENT_RING_BUFFER_SIZE 262144
-#define VORTEK_SERVER_PATH "/data/data/com.winlator/files/rootfs/tmp/.vortek/V0"
 #define VK_HANDLE_BYTE_COUNT 8
 #define THREAD_POOL_NUM_THREADS 8
 

--- a/app/src/main/cpp/vortekrenderer/src/shader_inspector.c
+++ b/app/src/main/cpp/vortekrenderer/src/shader_inspector.c
@@ -15,10 +15,12 @@
 #define WRITE_FILE(filename, code, sizeInBytes) \
     do { \
         char path[PATH_MAX] = {0}; \
-        sprintf(path, APP_CACHE_DIR "/%s", filename); \
+        snprintf(path, sizeof(path), "%s/%s", getAppCacheDir(), filename); \
         FILE* f = fopen(path, "wb"); \
-        fwrite((const char*)code, 1, sizeInBytes, f); \
-        fclose(f); \
+        if (f) { \
+            fwrite((const char*)code, 1, sizeInBytes, f); \
+            fclose(f); \
+        } \
     } \
     while(0)
 

--- a/app/src/main/cpp/vortekrenderer/src/texture_decoder.c
+++ b/app/src/main/cpp/vortekrenderer/src/texture_decoder.c
@@ -8,8 +8,11 @@
 #include "string_utils.h"
 #include "file_utils.h"
 
-#define CACHE_DIR APP_CACHE_DIR "/vortek"
 #define CACHE_MIN_IMAGE_WIDTH 1024
+
+static void getCacheDir(char* output, size_t size) {
+    snprintf(output, size, "%s/vortek", getAppCacheDir());
+}
 
 static bool isCanDecompressFormat(VkFormat format) {
     switch (format) {
@@ -96,19 +99,25 @@ static void internalDestroyImage(VkDevice device, TextureDecoder_Image* targetIm
 }
 
 static bool readCachedImage(TextureDecoder_Image* image, uint64_t hash) {
-    char filename[128] = {0};
-    sprintf(filename, CACHE_DIR "/%lx-%dx%d-%d.imd", hash, image->width, image->height, image->format);
+    char cacheDir[PATH_MAX] = {0};
+    char filename[PATH_MAX] = {0};
+    getCacheDir(cacheDir, sizeof(cacheDir));
+    snprintf(filename, sizeof(filename), "%s/%lx-%dx%d-%d.imd", cacheDir, hash, image->width, image->height, image->format);
 
-    createDirectory(CACHE_DIR);
+    createDirectory(cacheDir);
     size_t size = image->width * image->height * 4;
     return fileGetContents(filename, image->decompressedData, &size) ? true : false;
 }
 
 static void writeImageToCache(TextureDecoder* textureDecoder, TextureDecoder_Image* image, uint64_t hash) {
     if (textureDecoder->imageCacheSize == 0) return;
-    createDirectory(CACHE_DIR);
+    char cacheDir[PATH_MAX] = {0};
+    char cacheSizeFile[PATH_MAX] = {0};
+    getCacheDir(cacheDir, sizeof(cacheDir));
+    snprintf(cacheSizeFile, sizeof(cacheSizeFile), "%s/.cache-size", cacheDir);
+    createDirectory(cacheDir);
 
-    char* content = fileGetContents(CACHE_DIR "/.cache-size", NULL, NULL);
+    char* content = fileGetContents(cacheSizeFile, NULL, NULL);
     uint64_t currentCacheSize = 0;
     if (content) {
         currentCacheSize = strtoll(content, NULL, 10);
@@ -118,14 +127,14 @@ static void writeImageToCache(TextureDecoder* textureDecoder, TextureDecoder_Ima
     uint64_t maxCacheSize = (uint64_t)textureDecoder->imageCacheSize << 20;
     while (currentCacheSize > maxCacheSize) {
         FindFileInfo fileInfo = {0};
-        if (findFirstFile(CACHE_DIR, &fileInfo) && remove(fileInfo.path) == 0) {
+        if (findFirstFile(cacheDir, &fileInfo) && remove(fileInfo.path) == 0) {
             currentCacheSize -= fileInfo.size;
         }
         else return;
     }
 
-    char filename[128] = {0};
-    sprintf(filename, CACHE_DIR "/%lx-%dx%d-%d.imd", hash, image->width, image->height, image->format);
+    char filename[PATH_MAX] = {0};
+    snprintf(filename, sizeof(filename), "%s/%lx-%dx%d-%d.imd", cacheDir, hash, image->width, image->height, image->format);
     size_t size = image->width * image->height * 4;
 
     bool success = false;
@@ -133,7 +142,7 @@ static void writeImageToCache(TextureDecoder* textureDecoder, TextureDecoder_Ima
         currentCacheSize += size;
         char value[32] = {0};
         sprintf(value, "%ld", currentCacheSize);
-        success = filePutContents(CACHE_DIR "/.cache-size", value, strlen(value));
+        success = filePutContents(cacheSizeFile, value, strlen(value));
     }
 
     if (!success) remove(filename);

--- a/app/src/main/cpp/winlator/CMakeLists.txt
+++ b/app/src/main/cpp/winlator/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2 -Wno-unused-function -Wimplicit-function
 include_directories(include)
 
 add_library(winlator SHARED
+            src/app_paths.c
             src/drawable.c
             src/gpu_image.c
             src/gpu_helper.c

--- a/app/src/main/cpp/winlator/include/winlator.h
+++ b/app/src/main/cpp/winlator/include/winlator.h
@@ -11,7 +11,6 @@
 #define BITMASK_UNSET(bits, flag) bits &= ~flag
 #define GETEXP(x) (31 - __builtin_clz(x))
 
-#define APP_CACHE_DIR "/data/data/com.winlator/cache"
 #define LIBVULKAN_PATH "/system/lib64/libvulkan.so"
 
 #define CLOSEFD(x) \
@@ -37,6 +36,9 @@
 
 #include <unistd.h>
 #include <syscall.h>
+
+const char* getAppCacheDir();
+void setAppCacheDir(const char* path);
 
 static inline pid_t currentThreadId() {
 #ifdef __ANDROID__

--- a/app/src/main/cpp/winlator/src/app_paths.c
+++ b/app/src/main/cpp/winlator/src/app_paths.c
@@ -1,0 +1,20 @@
+#include <limits.h>
+#include <string.h>
+
+#include "winlator.h"
+
+static char appCacheDir[PATH_MAX] = {0};
+
+const char* getAppCacheDir() {
+    return appCacheDir;
+}
+
+void setAppCacheDir(const char* path) {
+    if (!path) {
+        appCacheDir[0] = '\0';
+        return;
+    }
+
+    strncpy(appCacheDir, path, sizeof(appCacheDir) - 1);
+    appCacheDir[sizeof(appCacheDir) - 1] = '\0';
+}

--- a/app/src/main/cpp/winlator/src/gpu_helper.c
+++ b/app/src/main/cpp/winlator/src/gpu_helper.c
@@ -14,6 +14,13 @@
 
 EGLContext globalEGLContext = EGL_NO_CONTEXT;
 
+JNIEXPORT void JNICALL
+Java_com_winlator_core_GPUHelper_initializeNativePaths(JNIEnv *env, jclass obj, jstring cacheDir) {
+    const char* cacheDirC = (*env)->GetStringUTFChars(env, cacheDir, NULL);
+    setAppCacheDir(cacheDirC);
+    (*env)->ReleaseStringUTFChars(env, cacheDir, cacheDirC);
+}
+
 JNIEXPORT jobjectArray JNICALL
 Java_com_winlator_core_GPUHelper_vkGetDeviceExtensions(JNIEnv *env, jclass obj) {
     VkInstanceCreateInfo createInfo = {0};
@@ -64,7 +71,10 @@ done:
 JNIEXPORT jint JNICALL
 Java_com_winlator_core_GPUHelper_vkGetApiVersion() {
     int version = 0;
-    char* content = fileGetContents(APP_CACHE_DIR "/.vk-api-version", NULL, NULL);
+    char cacheFile[PATH_MAX] = {0};
+    snprintf(cacheFile, sizeof(cacheFile), "%s/.vk-api-version", getAppCacheDir());
+
+    char* content = fileGetContents(cacheFile, NULL, NULL);
     if (content) {
         version = strtol(content, NULL, 10);
         MEMFREE(content);
@@ -116,7 +126,7 @@ Java_com_winlator_core_GPUHelper_vkGetApiVersion() {
 
     char value[32] = {0};
     sprintf(value, "%d", version);
-    filePutContents(APP_CACHE_DIR "/.vk-api-version", value, strlen(value));
+    filePutContents(cacheFile, value, strlen(value));
 
 done:
     if (instance) vkDestroyInstance(instance, NULL);

--- a/app/src/main/java/com/winlator/ContainerDetailFragment.java
+++ b/app/src/main/java/com/winlator/ContainerDetailFragment.java
@@ -461,7 +461,7 @@ public class ContainerDetailFragment extends Fragment {
         final LinearLayout parent = view.findViewById(R.id.LLDrives);
         final View emptyTextView = view.findViewById(R.id.TVDrivesEmptyText);
         LayoutInflater inflater = LayoutInflater.from(context);
-        final String drives = isEditMode() ? container.getDrives() : Container.DEFAULT_DRIVES;
+        final String drives = isEditMode() ? container.getDrives() : Container.getDefaultDrives(context);
         final String[] driveLetters = new String[Container.MAX_DRIVE_LETTERS];
         for (int i = 0; i < driveLetters.length; i++) driveLetters[i] = ((char)(i + 68))+":";
 
@@ -525,8 +525,8 @@ public class ContainerDetailFragment extends Fragment {
                     editText.setText(AppUtils.DIRECTORY_DOWNLOADS);
                     break;
                 case R.id.menu_item_internal_storage:
-                    drive.path = AppUtils.INTERNAL_STORAGE;
-                    editText.setText(AppUtils.INTERNAL_STORAGE);
+                    drive.path = AppUtils.getInternalStorage(activity);
+                    editText.setText(drive.path);
                     break;
                 default:
                     Container container = manager.getContainerById(menuItem.getOrder());

--- a/app/src/main/java/com/winlator/MainActivity.java
+++ b/app/src/main/java/com/winlator/MainActivity.java
@@ -28,6 +28,7 @@ import com.google.android.material.navigation.NavigationView;
 import com.winlator.contentdialog.AboutDialog;
 import com.winlator.core.AppUtils;
 import com.winlator.core.Callback;
+import com.winlator.core.GPUHelper;
 import com.winlator.core.LocaleHelper;
 import com.winlator.core.PreloaderDialog;
 import com.winlator.xenvironment.RootFSInstaller;
@@ -49,6 +50,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        GPUHelper.initialize(this);
         AppUtils.setActivityTheme(this);
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main_activity);

--- a/app/src/main/java/com/winlator/XServerDisplayActivity.java
+++ b/app/src/main/java/com/winlator/XServerDisplayActivity.java
@@ -48,6 +48,7 @@ import com.winlator.core.DefaultVersion;
 import com.winlator.core.EnvVars;
 import com.winlator.core.FileUtils;
 import com.winlator.core.GeneralComponents;
+import com.winlator.core.GPUHelper;
 import com.winlator.core.KeyValueSet;
 import com.winlator.core.LocaleHelper;
 import com.winlator.core.PreloaderDialog;
@@ -138,6 +139,7 @@ public class XServerDisplayActivity extends AppCompatActivity implements Navigat
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        GPUHelper.initialize(this);
         AppUtils.setActivityTheme(this);
         super.onCreate(savedInstanceState);
         AppUtils.hideSystemUI(this);
@@ -456,7 +458,7 @@ public class XServerDisplayActivity extends AppCompatActivity implements Navigat
         }
 
         WineStartMenuCreator.create(this, container);
-        WineUtils.createDosdevicesSymlinks(container, true);
+        WineUtils.createDosdevicesSymlinks(this, container, true);
 
         String startupSelection = String.valueOf(container.getStartupSelection());
         if (!startupSelection.equals(container.getExtra("startupSelection")) || wineprefixWasUpdated) {

--- a/app/src/main/java/com/winlator/container/Container.java
+++ b/app/src/main/java/com/winlator/container/Container.java
@@ -1,5 +1,7 @@
 package com.winlator.container;
 
+import android.content.Context;
+
 import com.winlator.box64.Box64Preset;
 import com.winlator.core.AppUtils;
 import com.winlator.core.EnvVars;
@@ -23,7 +25,7 @@ public class Container {
     public static final String DEFAULT_DXWRAPPER = DXWrappers.DXVK;
     public static final String DEFAULT_WINCOMPONENTS = "direct3d=1,directsound=1,directmusic=1,directshow=0,directplay=0,xaudio=1,vcrun2005=0,vcrun2010=1,wmdecoder=1";
     public static final String FALLBACK_WINCOMPONENTS = "direct3d=0,directsound=0,directmusic=0,directshow=0,directplay=0,xaudio=0,vcrun2005=0,vcrun2010=0,wmdecoder=0";
-    public static final String DEFAULT_DRIVES = "D:"+AppUtils.DIRECTORY_DOWNLOADS +"E:"+AppUtils.INTERNAL_STORAGE;
+    public static final String DEFAULT_DRIVES = "D:"+AppUtils.DIRECTORY_DOWNLOADS;
     public static final byte STARTUP_SELECTION_NORMAL = 0;
     public static final byte STARTUP_SELECTION_ESSENTIAL = 1;
     public static final byte STARTUP_SELECTION_AGGRESSIVE = 2;
@@ -53,6 +55,15 @@ public class Container {
     public Container(int id) {
         this.id = id;
         this.name = "Container-"+id;
+    }
+
+    public Container(Context context, int id) {
+        this(id);
+        drives = getDefaultDrives(context);
+    }
+
+    public static String getDefaultDrives(Context context) {
+        return DEFAULT_DRIVES+"E:"+AppUtils.getInternalStorage(context);
     }
 
     public String getName() {

--- a/app/src/main/java/com/winlator/container/ContainerManager.java
+++ b/app/src/main/java/com/winlator/container/ContainerManager.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Handler;
 
 import com.winlator.R;
+import com.winlator.core.AppUtils;
 import com.winlator.core.Callback;
 import com.winlator.core.FileUtils;
 import com.winlator.core.TarCompressorUtils;
@@ -50,10 +51,16 @@ public class ContainerManager {
                 for (File file : files) {
                     if (file.isDirectory()) {
                         if (file.getName().startsWith(RootFS.USER+"-")) {
-                            Container container = new Container(Integer.parseInt(file.getName().replace(RootFS.USER+"-", "")));
+                            Container container = new Container(context, Integer.parseInt(file.getName().replace(RootFS.USER+"-", "")));
                             container.setRootDir(new File(homeDir, RootFS.USER+"-"+container.id));
                             JSONObject data = new JSONObject(FileUtils.readString(container.getConfigFile()));
                             container.loadData(data);
+                            String drives = container.getDrives();
+                            String migratedDrives = drives.replace(AppUtils.LEGACY_INTERNAL_STORAGE, AppUtils.getInternalStorage(context));
+                            if (!migratedDrives.equals(drives)) {
+                                container.setDrives(migratedDrives);
+                                container.saveData();
+                            }
                             containers.add(container);
                             maxContainerId = Math.max(maxContainerId, container.id);
                         }
@@ -103,7 +110,7 @@ public class ContainerManager {
             File containerDir = new File(homeDir, RootFS.USER+"-"+id);
             if (!containerDir.mkdirs()) return null;
 
-            Container container = new Container(id);
+            Container container = new Container(context, id);
             container.setRootDir(containerDir);
             container.loadData(data);
 
@@ -135,7 +142,7 @@ public class ContainerManager {
             return;
         }
 
-        Container dstContainer = new Container(id);
+        Container dstContainer = new Container(context, id);
         dstContainer.setRootDir(dstDir);
         dstContainer.setName(srcContainer.getName()+" ("+context.getString(R.string.copy)+")");
         dstContainer.setScreenSize(srcContainer.getScreenSize());

--- a/app/src/main/java/com/winlator/core/AppUtils.java
+++ b/app/src/main/java/com/winlator/core/AppUtils.java
@@ -37,6 +37,7 @@ import com.google.android.material.tabs.TabLayout;
 import com.winlator.R;
 import com.winlator.SettingsFragment;
 
+import java.io.File;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Timer;
@@ -44,8 +45,14 @@ import java.util.TimerTask;
 
 public abstract class AppUtils {
     public static final String DIRECTORY_DOWNLOADS = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).getPath();
-    public static final String INTERNAL_STORAGE = "/data/data/com.winlator/storage";
+    public static final String LEGACY_INTERNAL_STORAGE = "/data/data/com.winlator/storage";
     private static WeakReference<Toast> globalToastReference = null;
+
+    public static String getInternalStorage(Context context) {
+        File directory = new File(context.getDataDir(), "storage");
+        if (!directory.isDirectory()) directory.mkdirs();
+        return directory.getPath();
+    }
 
     public static class RestartApplicationOptions {
         public int selectedMenuItemId;

--- a/app/src/main/java/com/winlator/core/GPUHelper.java
+++ b/app/src/main/java/com/winlator/core/GPUHelper.java
@@ -26,6 +26,10 @@ public abstract class GPUHelper {
         System.loadLibrary("winlator");
     }
 
+    public static void initialize(Context context) {
+        initializeNativePaths(context.getCacheDir().getPath());
+    }
+
     private static ArrayMap<String, String> loadGPUInformation(Context context) {
         final Thread thread = Thread.currentThread();
         final ArrayMap<String, String> gpuInfo = new ArrayMap<>();
@@ -155,6 +159,8 @@ public abstract class GPUHelper {
     }
 
     public static native String[] vkGetDeviceExtensions();
+
+    private static native void initializeNativePaths(String cacheDir);
 
     @CriticalNative
     public static native int vkGetApiVersion();

--- a/app/src/main/java/com/winlator/core/ProcessHelper.java
+++ b/app/src/main/java/com/winlator/core/ProcessHelper.java
@@ -2,6 +2,7 @@ package com.winlator.core;
 
 import android.os.Process;
 import android.system.Os;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 
@@ -23,6 +24,7 @@ import java.util.concurrent.Executors;
 import java.util.regex.Pattern;
 
 public abstract class ProcessHelper {
+    private static final String TAG = "ProcessHelper";
     public enum PState {RUNNING, SLEEPING, WAITING, ZOMBIE, STOPPED, DEAD, OTHER}
     private static final ArrayList<Callback<String>> debugCallbacks = new ArrayList<>();
     private static final byte SIGCONT = 18;
@@ -69,7 +71,9 @@ public abstract class ProcessHelper {
             if (debugCallbacks.isEmpty()) processBuilder.redirectOutput(new File("/dev/null")).redirectErrorStream(true);
 
             Map<String, String> environment = processBuilder.environment();
-            for (String name : envVars) environment.put(name, envVars.get(name));
+            if (envVars != null) {
+                for (String name : envVars) environment.put(name, envVars.get(name));
+            }
 
             java.lang.Process process = processBuilder.start();
             Field pidField = process.getClass().getDeclaredField("pid");
@@ -84,7 +88,9 @@ public abstract class ProcessHelper {
 
             if (terminationCallback != null) createWaitForThread(process, terminationCallback);
         }
-        catch (Exception e) {}
+        catch (Exception e) {
+            Log.e(TAG, "Failed to start process: "+command, e);
+        }
         return pid;
     }
 
@@ -101,7 +107,9 @@ public abstract class ProcessHelper {
                     }
                 }
             }
-            catch (IOException e) {}
+            catch (IOException e) {
+                Log.e(TAG, "Failed to read process output", e);
+            }
         });
     }
 
@@ -111,7 +119,10 @@ public abstract class ProcessHelper {
                 int status = process.waitFor();
                 terminationCallback.call(status);
             }
-            catch (InterruptedException e) {}
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                Log.e(TAG, "Interrupted while waiting for process", e);
+            }
         });
     }
 

--- a/app/src/main/java/com/winlator/core/ProfilePathRelocator.java
+++ b/app/src/main/java/com/winlator/core/ProfilePathRelocator.java
@@ -1,0 +1,162 @@
+package com.winlator.core;
+
+import android.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+
+public final class ProfilePathRelocator {
+    private static final String TAG = "ProfilePathRelocator";
+    private static final String OWNER_ROOT = "/data/data/com.winlator/files/rootfs";
+    private static final byte[] OWNER_ROOT_BYTES = OWNER_ROOT.getBytes(StandardCharsets.US_ASCII);
+    private static final int CHUNK_SIZE = 1024 * 1024;
+
+    private ProfilePathRelocator() {}
+
+    public static boolean shouldRelocate(File destination) {
+        return findRootDir(destination) != null;
+    }
+
+    private static File findRootDir(File location) {
+        String path = location.getAbsolutePath().replace('\\', '/');
+        int end = path.indexOf("/files/rootfs");
+        return end >= 0 ? new File(path.substring(0, end + "/files/rootfs".length())) : null;
+    }
+
+    private static String createStableRoot(File rootDir) {
+        File filesDir = rootDir.getParentFile();
+        File dataDir = filesDir != null ? filesDir.getParentFile() : null;
+        if (dataDir == null) return null;
+
+        String stableRoot = new File(dataDir, "r").getAbsolutePath().replace('\\', '/');
+        if (stableRoot.length() > OWNER_ROOT.length()) return null;
+
+        StringBuilder result = new StringBuilder(stableRoot);
+        while (result.length() < OWNER_ROOT.length()) result.append('/');
+        return result.toString();
+    }
+
+    public static boolean ensureRootAlias(File rootDir) {
+        String stableRoot = createStableRoot(rootDir);
+        if (stableRoot == null) {
+            Log.e(TAG, "Unable to create fixed-length rootfs alias for "+rootDir);
+            return false;
+        }
+
+        File alias = new File(stableRoot.replaceAll("/+$", ""));
+        String target = rootDir.getAbsolutePath();
+        if (FileUtils.isSymlink(alias) && target.equals(FileUtils.readSymlink(alias))) return true;
+
+        if (alias.exists() && !FileUtils.delete(alias)) {
+            Log.e(TAG, "Unable to replace rootfs alias "+alias);
+            return false;
+        }
+
+        FileUtils.symlink(target, alias.getAbsolutePath());
+        boolean success = FileUtils.isSymlink(alias) && target.equals(FileUtils.readSymlink(alias));
+        if (!success) Log.e(TAG, "Rootfs alias validation failed for "+alias+" -> "+target);
+        return success;
+    }
+
+    public static String relocatePath(String path, File location) {
+        if (path == null) return null;
+        File rootDir = findRootDir(location);
+        String stableRoot = rootDir != null ? createStableRoot(rootDir) : null;
+        return stableRoot != null ? path.replace(OWNER_ROOT, stableRoot) : path;
+    }
+
+    public static boolean relocateFile(File file) {
+        if (!file.isFile() || file.length() < OWNER_ROOT_BYTES.length) return true;
+
+        int bufferSize = (int)Math.min(
+            CHUNK_SIZE + OWNER_ROOT_BYTES.length - 1,
+            file.length()
+        );
+        return relocateFile(file, new byte[bufferSize]);
+    }
+
+    private static boolean relocateFile(File file, byte[] data) {
+        File rootDir = findRootDir(file);
+        String stableRoot = rootDir != null ? createStableRoot(rootDir) : null;
+        if (stableRoot == null) {
+            Log.e(TAG, "Unable to determine stable rootfs path for "+file);
+            return false;
+        }
+        byte[] stableRootBytes = stableRoot.getBytes(StandardCharsets.US_ASCII);
+
+        int replacements = 0;
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "rw");
+             FileChannel channel = randomAccessFile.getChannel()) {
+            long filePosition = 0;
+            long fileSize = channel.size();
+
+            while (filePosition < fileSize) {
+                int readLength = (int)Math.min(data.length, fileSize - filePosition);
+                ByteBuffer readBuffer = ByteBuffer.wrap(data, 0, readLength);
+                int bytesRead = channel.read(readBuffer, filePosition);
+                if (bytesRead <= 0) break;
+
+                int scanLength = Math.min(CHUNK_SIZE, bytesRead - OWNER_ROOT_BYTES.length + 1);
+                for (int position = 0; position < scanLength; position++) {
+                    if (data[position] != OWNER_ROOT_BYTES[0]) continue;
+
+                    boolean match = true;
+                    for (int offset = 1; offset < OWNER_ROOT_BYTES.length; offset++) {
+                        if (data[position + offset] != OWNER_ROOT_BYTES[offset]) {
+                            match = false;
+                            break;
+                        }
+                    }
+
+                    if (match) {
+                        channel.write(ByteBuffer.wrap(stableRootBytes), filePosition + position);
+                        replacements++;
+                        position += OWNER_ROOT_BYTES.length - 1;
+                    }
+                }
+
+                filePosition += CHUNK_SIZE;
+            }
+
+            if (replacements > 0) channel.force(false);
+            return true;
+        }
+        catch (IOException | RuntimeException e) {
+            Log.e(TAG, "Unable to relocate owner-profile paths in "+file, e);
+            return false;
+        }
+    }
+
+    public static boolean relocateTree(File root) {
+        if (!root.exists()) return true;
+        File rootDir = findRootDir(root);
+        return rootDir != null && relocateTree(
+            root,
+            rootDir,
+            new byte[CHUNK_SIZE + OWNER_ROOT_BYTES.length - 1]
+        );
+    }
+
+    private static boolean relocateTree(File root, File rootDir, byte[] data) {
+        if (FileUtils.isSymlink(root)) {
+            String target = FileUtils.readSymlink(root);
+            String relocatedTarget = relocatePath(target, rootDir);
+            if (!relocatedTarget.equals(target)) FileUtils.symlink(relocatedTarget, root.getPath());
+            return true;
+        }
+
+        if (root.isFile()) return root.length() < OWNER_ROOT_BYTES.length || relocateFile(root, data);
+
+        File[] files = root.listFiles();
+        if (files == null) return root.isDirectory();
+        for (File file : files) {
+            if (!relocateTree(file, rootDir, data)) return false;
+        }
+        return true;
+    }
+
+}

--- a/app/src/main/java/com/winlator/core/TarCompressorUtils.java
+++ b/app/src/main/java/com/winlator/core/TarCompressorUtils.java
@@ -147,6 +147,7 @@ public abstract class TarCompressorUtils {
 
     private static boolean extract(Type type, InputStream source, File destination, OnExtractFileListener onExtractFileListener) {
         if (source == null) return false;
+        boolean relocateProfilePaths = ProfilePathRelocator.shouldRelocate(destination);
         try (InputStream inStream = getCompressorInputStream(type, source);
              ArchiveInputStream tar = new TarArchiveInputStream(inStream)) {
             TarArchiveEntry entry;
@@ -164,12 +165,16 @@ public abstract class TarCompressorUtils {
                 }
                 else {
                     if (entry.isSymbolicLink()) {
-                        FileUtils.symlink(entry.getLinkName(), file.getAbsolutePath());
+                        String linkName = relocateProfilePaths
+                            ? ProfilePathRelocator.relocatePath(entry.getLinkName(), destination)
+                            : entry.getLinkName();
+                        FileUtils.symlink(linkName, file.getAbsolutePath());
                     }
                     else {
                         try (BufferedOutputStream outStream = new BufferedOutputStream(new FileOutputStream(file), StreamUtils.BUFFER_SIZE)) {
                             if (!StreamUtils.copy(tar, outStream)) return false;
                         }
+                        if (relocateProfilePaths && !ProfilePathRelocator.relocateFile(file)) return false;
                     }
                 }
 

--- a/app/src/main/java/com/winlator/core/WineUtils.java
+++ b/app/src/main/java/com/winlator/core/WineUtils.java
@@ -20,7 +20,7 @@ import java.util.Iterator;
 import java.util.Locale;
 
 public abstract class WineUtils {
-    public static void createDosdevicesSymlinks(Container container, boolean addDriveCDRom) {
+    public static void createDosdevicesSymlinks(Context context, Container container, boolean addDriveCDRom) {
         File rootDir = container.getRootDir();
         String dosdevicesPath = (new File(rootDir, ".wine/dosdevices")).getPath();
         File[] files = (new File(dosdevicesPath)).listFiles();
@@ -44,7 +44,7 @@ public abstract class WineUtils {
         for (Drive drive : container.drivesIterator()) {
             File linkTarget = new File(drive.path);
             String path = linkTarget.getAbsolutePath();
-            if (!linkTarget.isDirectory() && path.startsWith(AppUtils.INTERNAL_STORAGE)) {
+            if (!linkTarget.isDirectory() && path.startsWith(AppUtils.getInternalStorage(context))) {
                 linkTarget.mkdirs();
                 FileUtils.chmod(linkTarget, 0771);
             }

--- a/app/src/main/java/com/winlator/xenvironment/RootFSInstaller.java
+++ b/app/src/main/java/com/winlator/xenvironment/RootFSInstaller.java
@@ -13,6 +13,7 @@ import com.winlator.core.AppUtils;
 import com.winlator.core.DownloadProgressDialog;
 import com.winlator.core.FileUtils;
 import com.winlator.core.PreloaderDialog;
+import com.winlator.core.ProfilePathRelocator;
 import com.winlator.core.TarCompressorUtils;
 import com.winlator.core.WineInfo;
 
@@ -26,7 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class RootFSInstaller {
-    public static final byte LATEST_VERSION = 19; // TODO increment it on rootfs update
+    public static final byte LATEST_VERSION = 20; // Profile-safe rootfs paths
     public static final byte UPDATE_WINEPREFIX_VERSION = 16; // set it if main wine version change
     public static final String FILENAME = "rootfs.tzst";
 
@@ -55,10 +56,11 @@ public abstract class RootFSInstaller {
         dialog.show(R.string.installing_system_files);
         Executors.newSingleThreadExecutor().execute(() -> {
             clearRootDir(rootDir);
+            boolean aliasReady = ProfilePathRelocator.ensureRootAlias(rootDir);
             final long contentLength = TarCompressorUtils.getContentLength(TarCompressorUtils.Type.ZSTD, activity, FILENAME, rootDir);
             AtomicLong totalSizeRef = new AtomicLong();
 
-            boolean success = TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, activity, FILENAME, rootDir, (file, size) -> {
+            boolean success = aliasReady && TarCompressorUtils.extract(TarCompressorUtils.Type.ZSTD, activity, FILENAME, rootDir, (file, size) -> {
                 if (size > 0) {
                     long totalSize = totalSizeRef.addAndGet(size);
                     final int progress = (int)(((float)totalSize / contentLength) * 100);
@@ -67,7 +69,8 @@ public abstract class RootFSInstaller {
                 return file;
             });
 
-            if (success) {
+            File installedWineDir = new File(rootDir, "opt/installed-wine");
+            if (success && ProfilePathRelocator.relocateTree(installedWineDir)) {
                 rootFS.createRFSVersionFile(LATEST_VERSION);
                 resetContainerRFSVersions(activity);
             }

--- a/app/src/main/java/com/winlator/xenvironment/components/GuestProgramLauncherComponent.java
+++ b/app/src/main/java/com/winlator/xenvironment/components/GuestProgramLauncherComponent.java
@@ -3,6 +3,7 @@ package com.winlator.xenvironment.components;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Process;
+import android.util.Log;
 
 import androidx.preference.PreferenceManager;
 
@@ -15,6 +16,7 @@ import com.winlator.core.FileUtils;
 import com.winlator.core.GeneralComponents;
 import com.winlator.core.LocaleHelper;
 import com.winlator.core.ProcessHelper;
+import com.winlator.core.ProfilePathRelocator;
 import com.winlator.widget.LogView;
 import com.winlator.xconnector.UnixSocketConfig;
 import com.winlator.xenvironment.EnvironmentComponent;
@@ -24,6 +26,7 @@ import java.io.File;
 import java.util.List;
 
 public class GuestProgramLauncherComponent extends EnvironmentComponent {
+    private static final String TAG = "GuestProgramLauncher";
     private String guestExecutable;
     private static int pid = -1;
     private EnvVars envVars;
@@ -35,9 +38,13 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
     public void start() {
         synchronized (lock) {
             stop();
-            extractBox64File();
+            if (!prepareBox64()) {
+                if (terminationCallback != null) terminationCallback.call(-1);
+                return;
+            }
             copyDefaultBox64RCFile();
             pid = execGuestProgram();
+            if (pid == -1 && terminationCallback != null) terminationCallback.call(-1);
         }
     }
 
@@ -86,6 +93,12 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
     private int execGuestProgram() {
         RootFS rootFS = environment.getRootFS();
         File rootDir = rootFS.getRootDir();
+        Context context = environment.getContext();
+        String box64Version = getBox64Version(context);
+        if (box64Version.equals(DefaultVersion.BOX64) && !ProfilePathRelocator.ensureRootAlias(rootDir)) {
+            Log.e(TAG, "Stable rootfs alias is unavailable");
+            return -1;
+        }
 
         EnvVars envVars = new EnvVars();
         addBox64EnvVars(envVars);
@@ -96,16 +109,22 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
         envVars.put("TMPDIR", rootDir+"/tmp");
         envVars.put("DISPLAY", ":0");
         envVars.put("PATH", rootDir+rootFS.getWinePath()+"/bin:"+rootDir+"/usr/local/bin:"+rootDir+"/usr/bin");
-        envVars.put("LD_LIBRARY_PATH", rootFS.getLibDir().getPath());
+        if (box64Version.equals(DefaultVersion.BOX64)) {
+            envVars.put("LD_LIBRARY_PATH", "/system/lib64:"+context.getApplicationInfo().nativeLibraryDir);
+        }
+        else {
+            envVars.put("LD_LIBRARY_PATH", rootFS.getLibDir().getPath());
+        }
         envVars.put("BOX64_LD_LIBRARY_PATH", rootDir+"/lib/x86_64-linux-gnu");
         envVars.put("ANDROID_SYSVSHM_SERVER", rootDir+UnixSocketConfig.SYSVSHM_SERVER_PATH);
+        envVars.put("WINLATOR_ROOTFS", rootDir);
 
         if (this.envVars != null) envVars.putAll(this.envVars);
 
         File shmDir = new File(rootDir, "/tmp/shm");
         if (!shmDir.isDirectory()) shmDir.mkdirs();
 
-        String command = rootDir+"/usr/local/bin/box64 "+guestExecutable;
+        String command = getBox64Executable(context, box64Version)+" "+guestExecutable;
 
         return ProcessHelper.exec(command, envVars, rootDir, (status) -> {
             synchronized (lock) {
@@ -115,16 +134,38 @@ public class GuestProgramLauncherComponent extends EnvironmentComponent {
         });
     }
 
-    private void extractBox64File() {
+    private boolean prepareBox64() {
         Context context = environment.getContext();
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-        String box64Version = preferences.getString("box64_version", DefaultVersion.BOX64);
+        String box64Version = getBox64Version(context);
         String currentBox64Version = preferences.getString("current_box64_version", "");
+
+        if (box64Version.equals(DefaultVersion.BOX64)) {
+            File nativeLibraryDir = new File(context.getApplicationInfo().nativeLibraryDir);
+            boolean complete = new File(nativeLibraryDir, "libbox64launcher.so").isFile()
+                && new File(nativeLibraryDir, "libbox64.so").isFile()
+                && new File(nativeLibraryDir, "libglibcloader.so").isFile();
+            if (!complete) Log.e(TAG, "Packaged Box64 runtime is incomplete");
+            return complete;
+        }
 
         if (!box64Version.equals(currentBox64Version)) {
             GeneralComponents.extractFile(GeneralComponents.Type.BOX64, context, box64Version, DefaultVersion.BOX64);
             preferences.edit().putString("current_box64_version", box64Version).apply();
         }
+        return true;
+    }
+
+    private String getBox64Version(Context context) {
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+        return preferences.getString("box64_version", DefaultVersion.BOX64);
+    }
+
+    private File getBox64Executable(Context context, String box64Version) {
+        if (box64Version.equals(DefaultVersion.BOX64)) {
+            return new File(context.getApplicationInfo().nativeLibraryDir, "libbox64launcher.so");
+        }
+        return new File(environment.getRootFS().getRootDir(), "/usr/local/bin/box64");
     }
 
     private void copyDefaultBox64RCFile() {

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.github.luben:zstd-jni:1.5.2-3'
+        classpath 'org.apache.commons:commons-compress:1.20'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Summary

Allow Winlator containers to start in Samsung Secure Folder and other secondary Android profiles where native executables extracted into writable app data cannot be executed.

## Root cause

Winlator extracts Box64 into `files/rootfs/usr/local/bin` and launches it with `ProcessBuilder`. Samsung Knox blocks executing files from writable app-data directories inside Secure Folder, so startup fails before Wine can initialize. Several native and rootfs assets also embed the owner-profile path `/data/data/com.winlator`, which is not valid in secondary profiles.

## Changes

- Generate the default Box64 runtime from the existing compressed assets during the Android build and package it in the APK native-library directory.
- Add a small Bionic launcher that enters Box64 through the packaged glibc loader and preserves that launcher path for recursive Box64 process spawning.
- Relocate fixed owner-profile rootfs paths to a same-length, app-owned alias that resolves independently of the child process working directory.
- Derive internal storage and native cache paths from Android `Context`, including migration of legacy saved drive paths.
- Surface process launch failures through Logcat instead of silently swallowing them.
- Keep custom Box64 versions using the existing extracted-component path.

No generated Box64 binary is committed; the build task derives it from Winlator's existing `box64-0.4.0.tzst` and `rootfs.tzst` assets.

## Validation

- `assembleDebug` succeeds.
- `assembleRelease` succeeds.
- Verified end-to-end on Android 16 inside Samsung Secure Folder: rootfs installation completes, Box64 starts from the APK native directory, recursive `wineserver` launch succeeds, and the container desktop opens.
- The normal package ID, branding, and existing container data are preserved.
