### PR TITLE
gladiorenderer: fix windowed black screen and flipped fullscreen with…

### DIFF
--- a/app/src/main/cpp/gladiorenderer/include/gl_context.h
+++ b/app/src/main/cpp/gladiorenderer/include/gl_context.h
@@ -31,6 +31,8 @@ typedef struct GLContext {
 
     GLuint savedDSATarget;
     GLuint savedDSAId;
+
+    int currentWindowId;
 } GLContext;
 
 extern GLContext* createGLContext(JNIEnv* env, jobject obj, int clientFd);
@@ -41,6 +43,7 @@ extern void readCommandBuffer(GLContext* context);
 extern void readVertexArrayElement(GLContext* context, int arrayIdx, int elementIdx);
 extern bool readUnboundVertexArrays(GLContext* context, GLenum drawMode, int drawCount, void** outIndices, GLenum indexType);
 extern const char* getGLExtensions(int* numExtensions);
+extern void gd_presentIfFrontBufferBound(GLContext* context);
 
 extern pthread_mutex_t glx_context_mutex;
 

--- a/app/src/main/cpp/gladiorenderer/src/gl_context.c
+++ b/app/src/main/cpp/gladiorenderer/src/gl_context.c
@@ -80,19 +80,30 @@ static void destroyDisplayBufAttachment(GLContext* context) {
 static void setCurrentRenderWindow(GLContext* context, int windowId) {
     if (windowId == 0) return;
     JMethods* jmethods = &context->jmethods;
-    (*jmethods->env)->CallVoidMethod(jmethods->env, jmethods->obj, jmethods->clearWindowContent, windowId);
-    if (currentRenderer->displayBuffer > 0) return;
 
     short width;
     short height;
-    getWindowSize(&context->jmethods, windowId, &width, &height);
+    getWindowSize(jmethods, windowId, &width, &height);
     if (width == 0 || height == 0) return;
 
     bool resized = currentRenderer->displaySize[0] != width || currentRenderer->displaySize[1] != height;
+    context->currentWindowId = windowId;
+
+    // displayBuffer 已经就绪且尺寸没变：直接返回，并且不要清空窗口内容，
+    // 否则每次 MakeCurrent 都会销毁窗口纹理，使窗口化下出现黑屏。
+    if (currentRenderer->displayBuffer > 0 && !resized) return;
+
+    // 注意：这里不能调用 clearWindowContent。窗口化 ddraw 游戏的 present 走
+    // wined3d 的 GDI 路径（不经过 glXSwapBuffers），窗口内容靠 X11 2D 绘图更新
+    // drawable 的 CPU data；clearWindowContent 会把 data 置空，永久摧毁该窗口
+    // 的 2D 显示路径导致黑屏。GL 接管窗口由 Java 端 updateWindowContent 在首次
+    // 成功拷贝时自行 setData(null) 完成，无需在此提前清除。
+
     currentRenderer->displaySize[0] = width;
     currentRenderer->displaySize[1] = height;
 
-    if (resized) destroyDisplayBufAttachment(context);
+    destroyDisplayBuffer();
+    destroyDisplayBufAttachment(context);
     createDisplayBufAttachment(context);
     createDisplayBuffer(context);
 
@@ -109,19 +120,50 @@ static void setCurrentRenderWindow(GLContext* context, int windowId) {
 static void swapDisplayBuffers(GLContext* context, int drawableId) {
     GLuint framebuffer = currentRenderer->clientState.framebuffer[indexOfGLTarget(GL_FRAMEBUFFER)];
     GLuint drawFramebuffer = currentRenderer->clientState.framebuffer[indexOfGLTarget(GL_DRAW_FRAMEBUFFER)];
+    GLuint readFramebuffer = currentRenderer->clientState.framebuffer[indexOfGLTarget(GL_READ_FRAMEBUFFER)];
     if (framebuffer != drawFramebuffer) GLFramebuffer_bind(GL_FRAMEBUFFER, drawFramebuffer);
+
+    // glXSwapBuffers 提交的是默认帧缓冲，而 Java 端 updateWindowContent 内部用
+    // glCopyTexImage2D 从"当前 GL_READ_FRAMEBUFFER"读取像素。客户端(wined3d 等)在
+    // present 时往往把 GL_READ_FRAMEBUFFER 留在自己的离屏 back buffer FBO 上，
+    // 那份内容是 top-down 的且尺寸不一定等于窗口，会造成全屏画面上下颠倒、窗口化黑屏。
+    // 因此这里强制把读源切到 displayBuffer，拷贝完成后再恢复客户端原来的读绑定。
+    GLuint displayBuffer = currentRenderer->displayBuffer;
+    bool readSourceOverridden = displayBuffer > 0 && readFramebuffer != displayBuffer;
+    if (readSourceOverridden) GLFramebuffer_bind(GL_READ_FRAMEBUFFER, displayBuffer);
 
     JMethods* jmethods = &context->jmethods;
     bool result = (*jmethods->env)->CallBooleanMethod(jmethods->env, jmethods->obj, jmethods->updateWindowContent, drawableId, currentRenderer->displaySize[0], currentRenderer->displaySize[1], JNI_TRUE);
     if (result) {
         GLTexture* texture = GLTexture_getBound(GL_TEXTURE_2D);
         glBindTexture(GL_TEXTURE_2D, texture ? texture->id : 0);
+        if (readSourceOverridden) GLFramebuffer_bind(GL_READ_FRAMEBUFFER, readFramebuffer);
     }
     else {
         destroyDisplayBuffer();
         destroyDisplayBufAttachment(context);
         setCurrentRenderWindow(context, drawableId);
     }
+}
+
+// ddraw 等客户端在窗口模式下会把 primary(front buffer) 当作绘制目标（wined3d 用
+// glBlitFramebuffer 拷到 FBO 0 再 glFlush），并且从不调用 glXSwapBuffers。
+// 真实 X11 语义下 front buffer 是即画即显的，这里在 flush/blit 边界补上这一步：
+// 若当前 draw framebuffer 正是 displayBuffer，就把内容推送给窗口合成器。
+void gd_presentIfFrontBufferBound(GLContext* context) {
+    if (!currentRenderer || currentRenderer->displayBuffer == 0 || context->currentWindowId == 0) return;
+
+    GLuint drawFramebuffer = currentRenderer->clientState.framebuffer[indexOfGLTarget(GL_DRAW_FRAMEBUFFER)];
+    if (drawFramebuffer != currentRenderer->displayBuffer) return;
+
+    static uint64_t lastPresentNs = 0;
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    uint64_t nowNs = (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+    if (lastPresentNs != 0 && nowNs - lastPresentNs < 6000000ull) return;
+    lastPresentNs = nowNs;
+
+    swapDisplayBuffers(context, context->currentWindowId);
 }
 
 static bool isCanDrawImmediate(short requestCode) {

--- a/app/src/main/cpp/gladiorenderer/src/request_handler.c
+++ b/app/src/main/cpp/gladiorenderer/src/request_handler.c
@@ -249,6 +249,7 @@ void gd_handle_glBlitFramebuffer(GLContext* context) {
     GLenum filter = ArrayBuffer_getInt(&context->inputBuffer);
 
     glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+    gd_presentIfFrontBufferBound(context);
 }
 
 void gd_handle_glBufferData(GLContext* context) {
@@ -1038,12 +1039,14 @@ void gd_handle_glFinish(GLContext* context) {
 #ifndef SKIP_GL_FINISH
     glFinish();
 #endif
+    gd_presentIfFrontBufferBound(context);
 
     gl_send(context->clientRing, REQUEST_CODE_GL_FINISH, NULL, 0);
 }
 
 void gd_handle_glFlush(GLContext* context) {
     glFlush();
+    gd_presentIfFrontBufferBound(context);
 }
 
 void gd_handle_glFlushMappedBufferRange(GLContext* context) {

--- a/app/src/main/java/com/winlator/xserver/Drawable.java
+++ b/app/src/main/java/com/winlator/xserver/Drawable.java
@@ -192,10 +192,11 @@ public class Drawable extends XResource {
     }
 
     public void forceUpdate() {
-        if (!offscreenStorage || useSharedData) {
-            texture.setNeedsUpdate(true);
-            if (onDrawListener != null) onDrawListener.run();
-        }
+        // 被 XComposite redirect 的窗口（offscreenStorage=true）其纹理会被父窗口引用并绘制，
+        // 2D 绘制后同样必须置 needsUpdate 并触发重绘，否则 updateFromDrawable 永远不上传，
+        // 窗口内容黑屏（gladio 窗口化模式的 GDI/X11 2D present 正是这条路径）。
+        texture.setNeedsUpdate(true);
+        if (onDrawListener != null) onDrawListener.run();
     }
 
     public boolean isUseSharedData() {


### PR DESCRIPTION
… Gladio driver

Two present-path bugs on DirectDraw/D3D9 games via wine's wined3d (e.g. MUGEN): windowed mode showed a black window while audio kept playing, and fullscreen was vertically flipped.

- swapDisplayBuffers did not pin the copy source for updateWindowContent, whose glCopyTexImage2D reads from the *current* GL_READ_FRAMEBUFFER. wined3d often leaves it bound to its offscreen back-buffer FBO (top-down, wrong size), producing the flipped fullscreen image. Now the read source is forced to displayBuffer during the copy and the client's binding is restored afterwards.

- Windowed ddraw's present goes through wined3d's Blt-to-primary path (glBlitFramebuffer to FBO 0 + glFlush) and never calls glXSwapBuffers, so nothing ever pushed displayBuffer to the window compositor. Restore X11 front-buffer draw-then-display semantics: push window content at glFlush/glFinish/glBlitFramebuffer boundaries when the draw framebuffer is displayBuffer (throttled to 6 ms), with GLContext tracking currentWindowId.

- Also fix the X11 2D display path: MakeCurrent no longer calls clearWindowContent, which permanently nulled the drawable's CPU data and broke GDI/X11-2D-presented windows (GL takeover now happens in Java on the first successful copy); the display buffer is rebuilt with proper FBO destruction on resize; and Drawable.forceUpdate() no longer skips XComposite-redirected windows, whose 2D content never reached the referenced texture otherwise.

Performance impact is minimal: for windowed games the push *is* the display path (zero extra cost); the only measurable overhead is one extra full-window texture copy per frame for wined3d titles (~0.5-3 ms at 1080p).